### PR TITLE
Added listeners to watch the pointer.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "parser": "babel-eslint",
+  "rules": {
+    "camelcase": 1,
+    "indent": [1, 4],
+    "semi": [1, "never"],
+    "quotes": [1, "double"],
+    "brace-style": [1, "1tbs"],
+    "space-before-blocks": 2
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Poin #
+
+Poll the state of the pointer (be it mouse or touch).

--- a/index.js
+++ b/index.js
@@ -1,0 +1,46 @@
+const cursor = {
+    "isPressed": function() {
+        return this.pressed !== undefined
+    },
+    "wasJustPressed": function(delta) {
+        delta = delta || (1000 / 60)
+        return Date.now() - this.pressed < delta
+    },
+    "position": {"x": 0, "y": 0},
+    "pressed": undefined,
+}
+
+document.addEventListener("pointerdown", function(event) {
+    cursor.pressed = Date.now()
+})
+
+document.addEventListener("pointerup", function(event) {
+    cursor.pressed = undefined
+})
+
+document.addEventListener("pointermove", function(event) {
+    cursor.position.x = event.clientX
+    cursor.position.y = event.clientY
+
+    let element = document.getElementById(cursor.element)
+    if(element !== undefined) {
+        let bounds = element.getBoundingClientRect()
+
+        cursor.position.x -= bounds.x
+        cursor.position.y -= bounds.y
+
+        cursor.position.x /= bounds.width
+        cursor.position.y /= bounds.height
+
+        // x = Math.max(0, Math.min(1, x))
+        // y = Math.max(0, Math.min(1, y))
+
+        // x *= 16
+        // y *= 9
+
+        // x = Math.round(x * 16)
+        // y = Math.round(y * 9)
+    }
+})
+
+module.exports = cursor

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "poin",
+  "version": "1.0.0",
+  "description": "Poll the state of the pointer",
+  "main": "index.js",
+  "license": "MIT",
+  "contributors": [
+    "Andrew McPherson <@ehgoodenough>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ehgoodenough/poin"
+  }
+}


### PR DESCRIPTION
### Summary ###

While build out my games, I often need to check the where the mouse is on a given frame of my game loop, and whether it is or isn't pressed. This utility automatically adds those event listeners, and caches the state in a store.

This is a cousin of [Keyb](https://github.com/ehgoodenough/keyb), my utility for polling the state of the keyboard. I like to think that someday I'll umbrella all of these input libraries as "Inp".